### PR TITLE
Fix qBittorrent import when content_path is stale

### DIFF
--- a/src/torrent/clients/deluge.controller.ts
+++ b/src/torrent/clients/deluge.controller.ts
@@ -60,6 +60,8 @@ export class DelugeController implements ITorrentController {
 					return {
 						hash: t.id,
 						content_path: t.savePath,
+						save_path: t.savePath,
+						name: t.name,
 						category: t.label,
 						progress: t.isCompleted ? 1 : t.progress / 100,
 					}

--- a/src/torrent/torrent.controller.ts
+++ b/src/torrent/torrent.controller.ts
@@ -125,10 +125,10 @@ export class TorrentController {
 	}
 
 	private resolveTorrentContentPath(torrent: Torrent): string {
-		const candidates = [
-			torrent.content_path,
-			path.join(torrent.save_path, torrent.name),
-		].filter(Boolean)
+		const candidates = [torrent.content_path]
+		if (torrent.save_path && torrent.name) {
+			candidates.push(path.join(torrent.save_path, torrent.name))
+		}
 
 		for (const candidate of candidates) {
 			const mapped = this.mapDownloadPath(candidate)

--- a/src/torrent/torrent.controller.ts
+++ b/src/torrent/torrent.controller.ts
@@ -1,4 +1,10 @@
-import { copyFileSync, mkdirSync, readdirSync, unlinkSync } from 'node:fs'
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	unlinkSync,
+} from 'node:fs'
 import path from 'node:path'
 import environment from '../environment.js'
 import { TargetLibraryFile } from '../library/library.model.js'
@@ -109,34 +115,51 @@ export class TorrentController {
 		}
 	}
 
-	//TODO refactor this method to be more maintainable
-	private async importTorrentFiles(torrent: Torrent) {
-		let _path = path.resolve(
-			torrent.content_path.replace(
+	private mapDownloadPath(qbPath: string): string {
+		return path.resolve(
+			qbPath.replace(
 				environment.MOUNT_DOWNLOADS_TORRENT,
 				environment.MOUNT_DOWNLOADS_ONEPACERR,
 			),
 		)
+	}
+
+	private resolveTorrentContentPath(torrent: Torrent): string {
+		const candidates = [
+			torrent.content_path,
+			path.join(torrent.save_path, torrent.name),
+		].filter(Boolean)
+
+		for (const candidate of candidates) {
+			const mapped = this.mapDownloadPath(candidate)
+			if (existsSync(mapped)) {
+				if (candidate !== torrent.content_path) {
+					Logger.debug(
+						`Resolved torrent content path to '${mapped}' (qBittorrent reported '${torrent.content_path}')`,
+					)
+				}
+				return mapped
+			}
+		}
+
+		return this.mapDownloadPath(candidates[0])
+	}
+
+	//TODO refactor this method to be more maintainable
+	private async importTorrentFiles(torrent: Torrent) {
+		const contentPath = this.resolveTorrentContentPath(torrent)
 
 		let files: string[] = []
 
-		if (_path.endsWith('.mkv')) {
-			files = [_path]
+		if (contentPath.endsWith('.mkv')) {
+			files = [contentPath]
 			Logger.debug(`Processing 1 torrent file...`)
 		} else {
-			let mkvs = readdirSync(_path).filter(f => f.endsWith('.mkv'))
+			let mkvs = readdirSync(contentPath).filter(f => f.endsWith('.mkv'))
 			if (mkvs.length > 0)
 				Logger.debug(`Processing ${mkvs.length} torrent files...`)
-			for (let f of readdirSync(_path).filter(f => f.endsWith('.mkv'))) {
-				let fullPath = `${torrent.content_path}${torrent.content_path.includes('/') ? '/' : '\\'}${f}`
-				files.push(
-					path.resolve(
-						fullPath.replace(
-							environment.MOUNT_DOWNLOADS_TORRENT,
-							environment.MOUNT_DOWNLOADS_ONEPACERR,
-						),
-					),
-				)
+			for (let f of mkvs) {
+				files.push(this.mapDownloadPath(path.join(contentPath, f)))
 			}
 		}
 

--- a/src/torrent/torrent.controller.ts
+++ b/src/torrent/torrent.controller.ts
@@ -138,16 +138,18 @@ export class TorrentController {
 						`Resolved torrent content path to '${mapped}' (qBittorrent reported '${torrent.content_path}')`,
 					)
 				}
-				return mapped
+				return candidate
 			}
 		}
 
-		return this.mapDownloadPath(candidates[0])
+		return candidates[0]
 	}
 
 	//TODO refactor this method to be more maintainable
 	private async importTorrentFiles(torrent: Torrent) {
-		const contentPath = this.resolveTorrentContentPath(torrent)
+		const contentPath = this.mapDownloadPath(
+			this.resolveTorrentContentPath(torrent),
+		)
 
 		let files: string[] = []
 
@@ -159,7 +161,7 @@ export class TorrentController {
 			if (mkvs.length > 0)
 				Logger.debug(`Processing ${mkvs.length} torrent files...`)
 			for (let f of mkvs) {
-				files.push(this.mapDownloadPath(path.join(contentPath, f)))
+				files.push(path.join(contentPath, f))
 			}
 		}
 

--- a/src/torrent/torrent.model.ts
+++ b/src/torrent/torrent.model.ts
@@ -4,6 +4,8 @@ export type TorrentClient = 'qbittorrent' | 'utorrent' | 'deluge'
 export type Torrent = {
 	readonly hash: string
 	readonly content_path: string
+	readonly save_path: string
+	readonly name: string
 	readonly category?: string
 	readonly progress?: number
 }

--- a/src/torrent/torrent.model.ts
+++ b/src/torrent/torrent.model.ts
@@ -4,8 +4,8 @@ export type TorrentClient = 'qbittorrent' | 'utorrent' | 'deluge'
 export type Torrent = {
 	readonly hash: string
 	readonly content_path: string
-	readonly save_path: string
-	readonly name: string
+	readonly save_path?: string
+	readonly name?: string
 	readonly category?: string
 	readonly progress?: number
 }


### PR DESCRIPTION
**Problem**

When qBittorrent finishes a download, it can still report `content_path` under an `/incomplete/` directory even though the files have moved to the completed location. OnePacerr tried to import from that stale path, failed with "file not found", and never imported completed torrents.

**Solution**

Add `resolveTorrentContentPath` to fall back to `save_path + name` when `content_path` does not exist on disk. This matches where qBittorrent actually stores completed files.
