### PR TITLE
Log download queue status after checking torrent client

### DIFF
--- a/src/metadata/metadata.controller.ts
+++ b/src/metadata/metadata.controller.ts
@@ -15,6 +15,7 @@ import {
 	MetadataAbsentError,
 	TorrentInfo,
 } from './metada.model.js'
+import { QueueDownloadResult } from '../torrent/torrent.model.js'
 
 export class MetadataController {
 	private metadata: Metadata
@@ -160,10 +161,14 @@ export class MetadataController {
 									`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - Standard instead of extended [Download skipped]`,
 								)
 							} else {
-								Logger.info(
-									`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - Standard instead of extended [Download queued]`,
+								const queueResult = await this.addToDownloadQueue(
+									arc.part,
+									episode.episode,
+									true,
 								)
-								await this.addToDownloadQueue(arc.part, episode.episode, true)
+								Logger.info(
+									`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - Standard instead of extended [${this.formatDownloadQueueStatus(queueResult)}]`,
+								)
 							}
 						}
 					} else if (CRC32 == episode.standard) {
@@ -182,21 +187,21 @@ export class MetadataController {
 							)
 						}
 						continue
-					} else {
-						if (environment.SKIP_DOWNLOADS) {
-							Logger.info(
-								`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - CRC32 Mismatch [Download skipped]`,
-							)
 						} else {
-							Logger.info(
-								`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - CRC32 Mismatch [Download queued]`,
-							)
-							await this.addToDownloadQueue(
-								arc.part,
-								episode.episode,
-								environment.PREFER_EXTENDED && !!episode.extended,
-							)
-						}
+							if (environment.SKIP_DOWNLOADS) {
+								Logger.info(
+									`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - CRC32 Mismatch [Download skipped]`,
+								)
+							} else {
+								const queueResult = await this.addToDownloadQueue(
+									arc.part,
+									episode.episode,
+									environment.PREFER_EXTENDED && !!episode.extended,
+								)
+								Logger.info(
+									`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - CRC32 Mismatch [${this.formatDownloadQueueStatus(queueResult)}]`,
+								)
+							}
 					}
 				} else {
 					if (environment.SKIP_DOWNLOADS) {
@@ -204,13 +209,13 @@ export class MetadataController {
 							`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - Missing [Download skipped]`,
 						)
 					} else {
-						Logger.info(
-							`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - Missing [Download queued]`,
-						)
-						await this.addToDownloadQueue(
+						const queueResult = await this.addToDownloadQueue(
 							arc.part,
 							episode.episode,
 							environment.PREFER_EXTENDED && !!episode.extended,
+						)
+						Logger.info(
+							`Episode ${arc.part}-${String(episode.episode).padStart(2, '0')} - Missing [${this.formatDownloadQueueStatus(queueResult)}]`,
 						)
 					}
 				}
@@ -524,7 +529,7 @@ export class MetadataController {
 		arc: number,
 		episode: string | number,
 		extended?: boolean,
-	) {
+	): Promise<QueueDownloadResult> {
 		this.checkMetadataDownloaded()
 
 		let rsstitle = `${
@@ -549,7 +554,18 @@ export class MetadataController {
 			torrentInfo = await Context.rss.getTorrentInfo(rsstitle)
 		}
 
-		await Context.torrent.queueDownload(torrentInfo)
+		return await Context.torrent.queueDownload(torrentInfo)
+	}
+
+	private formatDownloadQueueStatus(result: QueueDownloadResult): string {
+		switch (result) {
+			case 'added':
+				return 'Download queued'
+			case 'already_present':
+				return 'Torrent already in client'
+			case 'skipped':
+				return 'Download skipped'
+		}
 	}
 
 	getEpisodeUpdatedCRC32(arc: number, episode: number): string {

--- a/src/torrent/torrent.controller.ts
+++ b/src/torrent/torrent.controller.ts
@@ -14,6 +14,7 @@ import { DelugeController } from './clients/deluge.controller.js'
 import { qBittorrentController } from './clients/qbittorrent.controller.js'
 import {
 	ITorrentController,
+	QueueDownloadResult,
 	Torrent,
 	TorrentClient,
 	TorrentConnectionError,
@@ -62,19 +63,23 @@ export class TorrentController {
 		}
 	}
 
-	public async queueDownload(torrentInfo: TorrentInfo) {
+	public async queueDownload(
+		torrentInfo: TorrentInfo,
+	): Promise<QueueDownloadResult> {
 		if (environment.SKIP_DOWNLOADS) {
 			Logger.info(`Downloads disabled by env vars`)
-			return
+			return 'skipped'
 		}
 
 		Logger.debug(`Adding magnetURI to ${this.client.torrentClient}...`)
 		let torrents = await this.client.getAllTorrents()
 		if (torrents.find(t => t.hash === torrentInfo.infoHash)) {
 			Logger.debug(`Torrent already in ${this.client.torrentClient}...`)
-			return
-		} else
-			await this.client.addTorrent(torrentInfo, environment.TORRENT_CATEGORY)
+			return 'already_present'
+		}
+
+		await this.client.addTorrent(torrentInfo, environment.TORRENT_CATEGORY)
+		return 'added'
 	}
 
 	private async processCompletedTorrents() {

--- a/src/torrent/torrent.model.ts
+++ b/src/torrent/torrent.model.ts
@@ -1,6 +1,7 @@
 import { TorrentInfo } from '../metadata/metada.model.js'
 
 export type TorrentClient = 'qbittorrent' | 'utorrent' | 'deluge'
+export type QueueDownloadResult = 'added' | 'already_present' | 'skipped'
 export type Torrent = {
 	readonly hash: string
 	readonly content_path: string


### PR DESCRIPTION
**Problem**

The metadata sync logs "Download queued" before checking whether the batch torrent is already in the client. When a batch torrent was already present, logs showed hundreds of misleading queue lines even though nothing new was added.

**Solution**

Check the torrent client first and return a `QueueDownloadResult` (`added`, `already_present`, or `skipped`). Log the actual outcome after the check so batch runs reflect what really happened.

**Example**

Before (batch torrent already in qBittorrent):

```
Episode 1-01 - Missing [Download queued]
Episode 1-02 - Missing [Download queued]
Episode 1-03 - Missing [Download queued]
Episode 1-04 - Missing [Download queued]
...
```

After:

```
Episode 1-01 - Missing [Torrent already in client]
Episode 1-02 - Missing [Torrent already in client]
Episode 1-03 - Missing [Torrent already in client]
Episode 1-04 - Missing [Torrent already in client]
...
```

When a torrent is actually added for the first time:

```
Episode 5-12 - Missing [Download queued]
Episode 5-13 - Missing [Torrent already in client]
```
