### PR TITLE
Use Emby-native season poster paths

### DIFF
--- a/src/library/library.controller.ts
+++ b/src/library/library.controller.ts
@@ -4,6 +4,7 @@ import environment from '../environment.js'
 import { Context } from '../util/context.js'
 import Logger from '../util/logger.js'
 import resolvePosterPath from '../util/resolve-poster-path.js'
+import resolveSeasonPosterFileName from '../util/resolve-season-poster-filename.js'
 import sanitizeWindowsFileName from '../util/sanitize-windows-filename.js'
 import { EmbyController } from './clients/emby.controller.js'
 import { JellyfinController } from './clients/jellyfin.controller.js'
@@ -166,10 +167,20 @@ export class LibraryController {
 				await Context.metadata.getSeasonNFO(arc),
 			)
 			if (!environment.SKIP_POSTERS) {
-				copyFileSync(
-					resolvePosterPath({ arc }),
-					`${path.resolve(`${folder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}poster.png`,
-				)
+				if (this.client.libraryClient === 'emby') {
+					let showFolder = await this.getLibraryFolder()
+					showFolder += showFolder.includes('/') ? '/' : '\\'
+					showFolder += environment.LIBRARY_SERIES_FOLDER_NAME
+					let posterDest = `${path.resolve(`${showFolder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}${resolveSeasonPosterFileName(arc)}`
+
+					mkdirSync(path.dirname(posterDest), { recursive: true })
+					copyFileSync(resolvePosterPath({ arc }), posterDest)
+				} else {
+					copyFileSync(
+						resolvePosterPath({ arc }),
+						`${path.resolve(`${folder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}poster.png`,
+					)
+				}
 			}
 		}
 

--- a/src/metadata/metadata.controller.ts
+++ b/src/metadata/metadata.controller.ts
@@ -3,6 +3,7 @@ import { copyFileSync, mkdirSync, readdirSync, unlinkSync } from 'fs'
 import path from 'path'
 import { js2xml } from 'xml-js'
 import environment from '../environment.js'
+import resolveSeasonPosterFileName from '../util/resolve-season-poster-filename.js'
 import { TargetLibraryFile } from '../library/library.model.js'
 import { Context } from '../util/context.js'
 import getFileCrc32Hash from '../util/crc32.js'
@@ -433,9 +434,13 @@ export class MetadataController {
 			path += path.includes('/') ? '/' : '\\'
 			path += environment.LIBRARY_SERIES_FOLDER_NAME
 			path += path.includes('/') ? '/' : '\\'
-			path += `Season ${String(a.part).padStart(2, '0')}`
-			path += path.includes('/') ? '/' : '\\'
-			path += `poster.png`
+			if (environment.LIBRARY_MEDIA_SERVER === 'emby') {
+				path += resolveSeasonPosterFileName(a.part)
+			} else {
+				path += `Season ${String(a.part).padStart(2, '0')}`
+				path += path.includes('/') ? '/' : '\\'
+				path += `poster.png`
+			}
 
 			let NFO = `<?xml version='1.0' encoding='utf-8'?>\n${js2xml(
 				{

--- a/src/util/resolve-season-poster-filename.ts
+++ b/src/util/resolve-season-poster-filename.ts
@@ -1,0 +1,3 @@
+export default function resolveSeasonPosterFileName(arc: number): string {
+	return `season${String(arc).padStart(2, '0')}-poster.png`
+}


### PR DESCRIPTION
**Problem**

Before emby support was officially added, I used the `none` media server, and added several of the season posters manually via emby's GUI. When I did, it put them in the show's root, eg `{show}/seasonXX-poster.png`. I'm now using the `emby` media server, and it writes to `{show}/Season XX/poster.png`.

Emby _does_ support `{show}/Season XX/poster.png`, so this isn't really a bug. But it doesn't match the default behavior of emby.

**Solution**

When `LIBRARY_MEDIA_SERVER=emby`, write season posters and season NFO poster paths to `seasonXX-poster.png` at the show root. Plex, Jellyfin, and local-folder behavior is unchanged.
