### PR TITLE
Improve Emby connection error messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { LabelsDisabledInDelugeError } from './torrent/clients/deluge.controller
 import { TorrentController } from './torrent/torrent.controller.js'
 import { TorrentConnectionError } from './torrent/torrent.model.js'
 import deprecatedWarnings from './util/deprecated-warnings.js'
+import { logErrorCause } from './util/format-connection-error.js'
 import Logger from './util/logger.js'
 
 const startApp = async () => {
@@ -55,7 +56,8 @@ const startApp = async () => {
 		Logger.info('APPLICATION STARTED SUCCESSFULLY...')
 	} catch (e) {
 		Logger.error('APPLICATION COULD NOT BE STARTED...')
-		Logger.error(e)
+		Logger.error(e instanceof Error ? e.message : e)
+		logErrorCause(e)
 		return gracefulClose()
 	}
 
@@ -71,7 +73,8 @@ const startApp = async () => {
 			Logger.debug(`Error handled, no need to crash...`)
 		} else {
 			Logger.error('APPLICATION CRASHED UNEXPECTEDLY...')
-			Logger.error(e)
+			Logger.error(e instanceof Error ? e.message : e)
+			logErrorCause(e)
 			gracefulClose()
 		}
 	}

--- a/src/library/clients/emby.client.ts
+++ b/src/library/clients/emby.client.ts
@@ -1,4 +1,15 @@
 import { randomUUID } from 'node:crypto'
+import { formatConnectionError } from '../../util/format-connection-error.js'
+
+const EMBY_CONNECT_HELP =
+	'Could not connect to Emby — check EMBY_URL and credentials'
+
+export class EmbyConnectionError extends Error {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options)
+		this.name = 'EmbyConnectionError'
+	}
+}
 
 export interface EmbyConfig {
 	baseUrl: string
@@ -59,6 +70,25 @@ class EmbyClient {
 
 	constructor(private config: EmbyConfig) {}
 
+	private connectionError(label: string, error: unknown): EmbyConnectionError {
+		return new EmbyConnectionError(
+			`${EMBY_CONNECT_HELP}. ${formatConnectionError(label, this.config.baseUrl, error)}`,
+			{ cause: error },
+		)
+	}
+
+	private async fetchEmby(
+		url: string,
+		label: string,
+		options?: RequestInit,
+	): Promise<Response> {
+		try {
+			return await fetch(url, options)
+		} catch (error) {
+			throw this.connectionError(label, error)
+		}
+	}
+
 	private async request<T>(
 		path: string,
 		options: { method?: string; params?: Record<string, string> } = {},
@@ -71,13 +101,15 @@ class EmbyClient {
 		const headers: Record<string, string> = {}
 		headers['X-Emby-Token'] = this.auth.AccessToken
 
-		const res = await fetch(url.toString(), {
+		const res = await this.fetchEmby(url.toString(), `Emby API ${path}`, {
 			method: options.method ?? 'GET',
 			headers,
 		})
 
 		if (!res.ok) {
-			throw new Error(`Emby request failed: ${res.status} ${res.statusText}`)
+			throw new EmbyConnectionError(
+				`${EMBY_CONNECT_HELP}. Emby request failed (${path}): HTTP ${res.status} ${res.statusText} at ${this.config.baseUrl}`,
+			)
 		}
 
 		const text = await res.text()
@@ -85,8 +117,9 @@ class EmbyClient {
 	}
 
 	async login(deviceId?: string) {
-		const res = await fetch(
+		const res = await this.fetchEmby(
 			`${this.config.baseUrl}/emby/Users/AuthenticateByName`,
+			'Emby login',
 			{
 				method: 'POST',
 				headers: {
@@ -99,7 +132,12 @@ class EmbyClient {
 				}),
 			},
 		)
-		if (!res.ok) throw new Error(`Login failed: ${res.status}`)
+
+		if (!res.ok) {
+			throw new EmbyConnectionError(
+				`${EMBY_CONNECT_HELP}. Emby login failed for user '${this.config.username}' at ${this.config.baseUrl}: HTTP ${res.status} ${res.statusText}`,
+			)
+		}
 
 		this.auth = await res.json()
 	}

--- a/src/library/clients/emby.client.ts
+++ b/src/library/clients/emby.client.ts
@@ -1,15 +1,9 @@
 import { randomUUID } from 'node:crypto'
 import { formatConnectionError } from '../../util/format-connection-error.js'
+import { LibraryConnectionError } from '../library.model.js'
 
 const EMBY_CONNECT_HELP =
 	'Could not connect to Emby — check EMBY_URL and credentials'
-
-export class EmbyConnectionError extends Error {
-	constructor(message: string, options?: { cause?: unknown }) {
-		super(message, options)
-		this.name = 'EmbyConnectionError'
-	}
-}
 
 export interface EmbyConfig {
 	baseUrl: string
@@ -70,8 +64,11 @@ class EmbyClient {
 
 	constructor(private config: EmbyConfig) {}
 
-	private connectionError(label: string, error: unknown): EmbyConnectionError {
-		return new EmbyConnectionError(
+	private connectionError(
+		label: string,
+		error: unknown,
+	): LibraryConnectionError {
+		return new LibraryConnectionError(
 			`${EMBY_CONNECT_HELP}. ${formatConnectionError(label, this.config.baseUrl, error)}`,
 			{ cause: error },
 		)
@@ -107,7 +104,7 @@ class EmbyClient {
 		})
 
 		if (!res.ok) {
-			throw new EmbyConnectionError(
+			throw new LibraryConnectionError(
 				`${EMBY_CONNECT_HELP}. Emby request failed (${path}): HTTP ${res.status} ${res.statusText} at ${this.config.baseUrl}`,
 			)
 		}
@@ -134,7 +131,7 @@ class EmbyClient {
 		)
 
 		if (!res.ok) {
-			throw new EmbyConnectionError(
+			throw new LibraryConnectionError(
 				`${EMBY_CONNECT_HELP}. Emby login failed for user '${this.config.username}' at ${this.config.baseUrl}: HTTP ${res.status} ${res.statusText}`,
 			)
 		}

--- a/src/library/clients/emby.controller.ts
+++ b/src/library/clients/emby.controller.ts
@@ -11,10 +11,13 @@ import {
 } from '../library.model.js'
 import EmbyClient, {
 	EmbyConfig,
+	EmbyConnectionError,
 	EmbyItem,
 	EmbyLibrary,
 	EmbyVirtualFolder,
 } from './emby.client.js'
+
+export { EmbyConnectionError }
 
 export class EmbyController implements ILibraryController {
 	readonly libraryClient: LibraryClient = 'emby'
@@ -27,31 +30,42 @@ export class EmbyController implements ILibraryController {
 
 	constructor(config: EmbyConfig) {
 		if (!config.baseUrl || !config.username || !config.password) {
-			throw new Error(`Emby misconfigured`)
+			throw new EmbyConnectionError(
+				'Could not connect to Emby — check EMBY_URL and credentials. Set EMBY_URL, EMBY_USERNAME, and EMBY_PASSWORD',
+			)
 		}
 		this.emby = new EmbyClient(config)
 	}
 
 	async init() {
-		Logger.info(`Authenticating to Emby...`)
+		Logger.info(`Authenticating to Emby at ${environment.EMBY_URL}...`)
 		await this.emby.login()
 
-		Logger.info(`Searching for Emby Library...`)
+		Logger.info(`Searching for Emby Library '${environment.EMBY_LIBRARY_NAME}'...`)
 		this.library = (await this.emby.getLibraries()).find(
 			l => l.Name == environment.EMBY_LIBRARY_NAME,
 		)
 
 		if (!this.library) {
-			Logger.error(
-				`Library '${environment.EMBY_LIBRARY_NAME}' not found on Emby...`,
+			const available = (await this.emby.getLibraries())
+				.map(l => l.Name)
+				.join(', ')
+			throw new EmbyConnectionError(
+				`Emby library '${environment.EMBY_LIBRARY_NAME}' not found at ${environment.EMBY_URL}. Available libraries: ${available || 'none'}`,
 			)
-			throw new Error()
 		}
 
 		Logger.info(`Searching for Emby Virtual Folder...`)
-		this.virtualFolder = (
-			await this.emby.getLibraryLocations(this.library.Name)
-		)[0]
+		const virtualFolders = await this.emby.getLibraryLocations(
+			this.library.Name,
+		)
+		this.virtualFolder = virtualFolders[0]
+
+		if (!this.virtualFolder?.Locations?.[0]) {
+			throw new EmbyConnectionError(
+				`Emby library '${this.library.Name}' has no folder locations configured at ${environment.EMBY_URL}`,
+			)
+		}
 
 		await this.fetchShow()
 	}

--- a/src/library/clients/emby.controller.ts
+++ b/src/library/clients/emby.controller.ts
@@ -7,17 +7,15 @@ import { LibraryController } from '../library.controller.js'
 import {
 	ILibraryController,
 	LibraryClient,
+	LibraryConnectionError,
 	TargetLibraryFile,
 } from '../library.model.js'
 import EmbyClient, {
 	EmbyConfig,
-	EmbyConnectionError,
 	EmbyItem,
 	EmbyLibrary,
 	EmbyVirtualFolder,
 } from './emby.client.js'
-
-export { EmbyConnectionError }
 
 export class EmbyController implements ILibraryController {
 	readonly libraryClient: LibraryClient = 'emby'
@@ -28,9 +26,9 @@ export class EmbyController implements ILibraryController {
 	private virtualFolder: EmbyVirtualFolder
 	private show: EmbyItem
 
-	constructor(config: EmbyConfig) {
+	constructor(private config: EmbyConfig) {
 		if (!config.baseUrl || !config.username || !config.password) {
-			throw new EmbyConnectionError(
+			throw new LibraryConnectionError(
 				'Could not connect to Emby — check EMBY_URL and credentials. Set EMBY_URL, EMBY_USERNAME, and EMBY_PASSWORD',
 			)
 		}
@@ -38,10 +36,12 @@ export class EmbyController implements ILibraryController {
 	}
 
 	async init() {
-		Logger.info(`Authenticating to Emby at ${environment.EMBY_URL}...`)
+		Logger.info(`Authenticating to Emby at ${this.config.baseUrl}...`)
 		await this.emby.login()
 
-		Logger.info(`Searching for Emby Library '${environment.EMBY_LIBRARY_NAME}'...`)
+		Logger.info(
+			`Searching for Emby Library '${environment.EMBY_LIBRARY_NAME}'...`,
+		)
 		this.library = (await this.emby.getLibraries()).find(
 			l => l.Name == environment.EMBY_LIBRARY_NAME,
 		)
@@ -50,8 +50,8 @@ export class EmbyController implements ILibraryController {
 			const available = (await this.emby.getLibraries())
 				.map(l => l.Name)
 				.join(', ')
-			throw new EmbyConnectionError(
-				`Emby library '${environment.EMBY_LIBRARY_NAME}' not found at ${environment.EMBY_URL}. Available libraries: ${available || 'none'}`,
+			throw new LibraryConnectionError(
+				`Emby library '${environment.EMBY_LIBRARY_NAME}' not found at ${this.config.baseUrl}. Available libraries: ${available || 'none'}`,
 			)
 		}
 
@@ -62,8 +62,8 @@ export class EmbyController implements ILibraryController {
 		this.virtualFolder = virtualFolders[0]
 
 		if (!this.virtualFolder?.Locations?.[0]) {
-			throw new EmbyConnectionError(
-				`Emby library '${this.library.Name}' has no folder locations configured at ${environment.EMBY_URL}`,
+			throw new LibraryConnectionError(
+				`Emby library '${this.library.Name}' has no folder locations configured at ${this.config.baseUrl}`,
 			)
 		}
 

--- a/src/library/clients/jellyfin.controller.ts
+++ b/src/library/clients/jellyfin.controller.ts
@@ -17,6 +17,7 @@ import { LibraryController } from '../library.controller.js'
 import {
 	ILibraryController,
 	LibraryClient,
+	LibraryConnectionError,
 	TargetLibraryFile,
 } from '../library.model.js'
 
@@ -31,7 +32,9 @@ export class JellyfinController implements ILibraryController {
 	private virtualFolder: VirtualFolderInfo
 	private show
 
-	constructor(config: { baseUrl: string; username: string; password: string }) {
+	constructor(
+		private config: { baseUrl: string; username: string; password: string },
+	) {
 		if (!config.baseUrl || !config.username || !config.password)
 			throw new Error(`Jellyfin misconfigured`)
 
@@ -55,20 +58,40 @@ export class JellyfinController implements ILibraryController {
 	}
 
 	async init() {
-		Logger.info(`Authenticating to Jellyfin...`)
-		let { data } = await getUserApi(this.api).authenticateUserByName({
+		Logger.info(`Authenticating to Jellyfin at ${this.config.baseUrl}...`)
+		await getUserApi(this.api).authenticateUserByName({
 			authenticateUserByName: this.credentials,
 		})
 
-		Logger.info(`Searching for Jellyfin Library...`)
+		Logger.info(
+			`Searching for Jellyfin Library '${environment.JELLYFIN_LIBRARY_NAME}'...`,
+		)
 		this.library = (
 			await getLibraryApi(this.api).getMediaFolders()
 		).data.Items.find(mf => mf.Name == environment.JELLYFIN_LIBRARY_NAME)
 
+		if (!this.library) {
+			const available = (
+				await getLibraryApi(this.api).getMediaFolders()
+			).data.Items.map(l => l.Name).join(', ')
+
+			throw new LibraryConnectionError(
+				`Emby library '${environment.JELLYFIN_LIBRARY_NAME}' not found at ${this.config.baseUrl}. Available libraries: ${available || 'none'}`,
+			)
+		}
+
 		Logger.info(`Searching for Jellyfin Virtual Folder...`)
-		this.virtualFolder = (
+		const virtualFolders = (
 			await getLibraryStructureApi(this.api).getVirtualFolders()
 		).data.find(vf => vf.Name == environment.JELLYFIN_LIBRARY_NAME)
+
+		this.virtualFolder = virtualFolders[0]
+
+		if (!this.virtualFolder?.Locations?.[0]) {
+			throw new LibraryConnectionError(
+				`Emby library '${this.library.Name}' has no folder locations configured at ${this.config.baseUrl}`,
+			)
+		}
 
 		await this.fetchShow()
 	}

--- a/src/library/library.model.ts
+++ b/src/library/library.model.ts
@@ -4,6 +4,13 @@ export type TargetLibraryFile = {
 	readonly filename: string
 }
 
+export class LibraryConnectionError extends Error {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options)
+		this.name = 'EmbyConnectionError'
+	}
+}
+
 export interface ILibraryController {
 	readonly libraryClient: LibraryClient
 

--- a/src/util/format-connection-error.ts
+++ b/src/util/format-connection-error.ts
@@ -1,0 +1,40 @@
+import Logger from './logger.js'
+
+export function formatConnectionError(
+	label: string,
+	url: string,
+	error: unknown,
+): string {
+	const parts = [`${label}: could not reach ${url}`]
+
+	if (error instanceof Error) {
+		const cause = error.cause
+		if (cause instanceof Error) {
+			parts.push(`cause: ${cause.message}`)
+			const code = (cause as NodeJS.ErrnoException).code
+			if (code) parts.push(`code: ${code}`)
+		} else if (error.message && error.message !== 'fetch failed') {
+			parts.push(error.message)
+		}
+	}
+
+	if (/localhost|127\.0\.0\.1/.test(url)) {
+		parts.push(
+			'hint: localhost is the OnePacerr container — use the Emby service hostname instead',
+		)
+	}
+
+	return parts.join(' — ')
+}
+
+export function logErrorCause(error: unknown) {
+	if (!(error instanceof Error) || !error.cause) return
+
+	if (error.cause instanceof Error) {
+		Logger.error(`Caused by: ${error.cause.message}`)
+		const code = (error.cause as NodeJS.ErrnoException).code
+		if (code) Logger.error(`Error code: ${code}`)
+	} else {
+		Logger.error(`Caused by: ${error.cause}`)
+	}
+}


### PR DESCRIPTION
**Problem**

A misconfigured `EMBY_URL` caused startup to crash with an unhelpful `fetch failed` and no indication of which URL failed or why.

**Solution**

Wrap Emby fetch failures in `EmbyConnectionError` with the configured URL, underlying cause, and a hint when localhost is involved. Add `format-connection-error.ts` and log error causes generically at startup so connection problems are easier to diagnose.

**Example**

Before (`EMBY_URL=http://localhost:8096` from inside the OnePacerr container):

```
Authenticating to Emby...
APPLICATION CRASHED UNEXPECTEDLY...
TypeError: fetch failed
```

After:

```
Authenticating to Emby...
APPLICATION CRASHED UNEXPECTEDLY...
Could not connect to Emby — check EMBY_URL and credentials. Emby login: could not reach http://localhost:8096 — cause: connect ECONNREFUSED 127.0.0.1:8096 — code: ECONNREFUSED — hint: localhost is the OnePacerr container — use the Emby service hostname instead
Caused by: connect ECONNREFUSED 127.0.0.1:8096
Error code: ECONNREFUSED
```
