### PR TITLE
Fix local-folder series root paths for none mode

### DIFF
--- a/src/library/clients/jellyfin.controller.ts
+++ b/src/library/clients/jellyfin.controller.ts
@@ -76,20 +76,18 @@ export class JellyfinController implements ILibraryController {
 			).data.Items.map(l => l.Name).join(', ')
 
 			throw new LibraryConnectionError(
-				`Emby library '${environment.JELLYFIN_LIBRARY_NAME}' not found at ${this.config.baseUrl}. Available libraries: ${available || 'none'}`,
+				`Jellyfin library '${environment.JELLYFIN_LIBRARY_NAME}' not found at ${this.config.baseUrl}. Available libraries: ${available || 'none'}`,
 			)
 		}
 
 		Logger.info(`Searching for Jellyfin Virtual Folder...`)
-		const virtualFolders = (
+		this.virtualFolder = (
 			await getLibraryStructureApi(this.api).getVirtualFolders()
 		).data.find(vf => vf.Name == environment.JELLYFIN_LIBRARY_NAME)
 
-		this.virtualFolder = virtualFolders[0]
-
 		if (!this.virtualFolder?.Locations?.[0]) {
 			throw new LibraryConnectionError(
-				`Emby library '${this.library.Name}' has no folder locations configured at ${this.config.baseUrl}`,
+				`Jellyfin library '${this.library.Name}' has no folder locations configured at ${this.config.baseUrl}`,
 			)
 		}
 

--- a/src/library/library.controller.ts
+++ b/src/library/library.controller.ts
@@ -4,6 +4,10 @@ import environment from '../environment.js'
 import { Context } from '../util/context.js'
 import Logger from '../util/logger.js'
 import resolvePosterPath from '../util/resolve-poster-path.js'
+import resolveSeasonPosterFileName from '../util/resolve-season-poster-filename.js'
+import resolveSeriesRootFolder, {
+	resolveSeasonFolder,
+} from '../util/resolve-series-root-folder.js'
 import sanitizeWindowsFileName from '../util/sanitize-windows-filename.js'
 import { EmbyController } from './clients/emby.controller.js'
 import { JellyfinController } from './clients/jellyfin.controller.js'
@@ -86,9 +90,7 @@ export class LibraryController {
 	}
 
 	async scanLibrary(folder: string, arc: number) {
-		let libraryFolder = await this.getLibraryFolder()
-		libraryFolder += libraryFolder.includes('/') ? '/' : '\\'
-		libraryFolder += environment.LIBRARY_SERIES_FOLDER_NAME
+		let libraryFolder = resolveSeriesRootFolder(await this.getLibraryFolder())
 
 		mkdirSync(
 			`${path.resolve(`${libraryFolder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}`,
@@ -128,11 +130,7 @@ export class LibraryController {
 			this.client.libraryClient != 'plex' ||
 			!environment.PLEX_SKIP_METADATA_FILES
 		) {
-			let folder = await this.getLibraryFolder()
-			folder += folder.includes('/') ? '/' : '\\'
-			folder += environment.LIBRARY_SERIES_FOLDER_NAME
-			folder += folder.includes('/') ? '/' : '\\'
-			folder += `Season ${String(arc).padStart(2, '0')}`
+			let folder = resolveSeasonFolder(await this.getLibraryFolder(), arc)
 
 			mkdirSync(
 				`${path.resolve(`${folder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}`,
@@ -151,11 +149,13 @@ export class LibraryController {
 			this.client.libraryClient != 'plex' ||
 			!environment.PLEX_SKIP_METADATA_FILES
 		) {
-			let folder = await this.getLibraryFolder()
-			folder += folder.includes('/') ? '/' : '\\'
-			folder += environment.LIBRARY_SERIES_FOLDER_NAME
-			folder += folder.includes('/') ? '/' : '\\'
-			folder += `Season ${String(arc).padStart(2, '0')}`
+			let folder = resolveSeasonFolder(await this.getLibraryFolder(), arc)
+			let showFolder = path.resolve(
+				resolveSeriesRootFolder(await this.getLibraryFolder()).replace(
+					environment.MOUNT_LIBRARY_MEDIA_SERVER,
+					environment.MOUNT_LIBRARY_ONEPACERR,
+				),
+			)
 
 			mkdirSync(
 				`${path.resolve(`${folder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}`,
@@ -166,10 +166,18 @@ export class LibraryController {
 				await Context.metadata.getSeasonNFO(arc),
 			)
 			if (!environment.SKIP_POSTERS) {
-				copyFileSync(
-					resolvePosterPath({ arc }),
-					`${path.resolve(`${folder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}poster.png`,
-				)
+				if (this.client.libraryClient === 'none') {
+					mkdirSync(showFolder, { recursive: true })
+					copyFileSync(
+						resolvePosterPath({ arc }),
+						`${showFolder}${path.sep}${resolveSeasonPosterFileName(arc)}`,
+					)
+				} else {
+					copyFileSync(
+						resolvePosterPath({ arc }),
+						`${path.resolve(`${folder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}poster.png`,
+					)
+				}
 			}
 		}
 
@@ -182,17 +190,17 @@ export class LibraryController {
 			!environment.PLEX_SKIP_METADATA_FILES
 		) {
 			if (!environment.SKIP_POSTERS) {
-				let libraryFolder = await this.getLibraryFolder()
-				libraryFolder += libraryFolder.includes('/') ? '/' : '\\'
-				libraryFolder += environment.LIBRARY_SERIES_FOLDER_NAME
-
-				mkdirSync(
-					`${path.resolve(`${libraryFolder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}`,
-					{ recursive: true },
+				let libraryFolder = path.resolve(
+					resolveSeriesRootFolder(await this.getLibraryFolder()).replace(
+						environment.MOUNT_LIBRARY_MEDIA_SERVER,
+						environment.MOUNT_LIBRARY_ONEPACERR,
+					),
 				)
+
+				mkdirSync(`${libraryFolder}${path.sep}`, { recursive: true })
 				copyFileSync(
 					resolvePosterPath(),
-					`${path.resolve(`${libraryFolder.replace(environment.MOUNT_LIBRARY_MEDIA_SERVER, environment.MOUNT_LIBRARY_ONEPACERR)}`)}${path.sep}poster.png`,
+					`${libraryFolder}${path.sep}poster.png`,
 				)
 			}
 		}

--- a/src/metadata/metadata.controller.ts
+++ b/src/metadata/metadata.controller.ts
@@ -3,6 +3,8 @@ import { copyFileSync, mkdirSync, readdirSync, unlinkSync } from 'fs'
 import path from 'path'
 import { js2xml } from 'xml-js'
 import environment from '../environment.js'
+import resolveSeasonPosterFileName from '../util/resolve-season-poster-filename.js'
+import resolveSeriesRootFolder from '../util/resolve-series-root-folder.js'
 import { TargetLibraryFile } from '../library/library.model.js'
 import { Context } from '../util/context.js'
 import getFileCrc32Hash from '../util/crc32.js'
@@ -385,9 +387,7 @@ export class MetadataController {
 
 		delete tvshow.customrating
 
-		let path = await Context.library.getLibraryFolder()
-		path += path.includes('/') ? '/' : '\\'
-		path += environment.LIBRARY_SERIES_FOLDER_NAME
+		let path = resolveSeriesRootFolder(await Context.library.getLibraryFolder())
 		path += path.includes('/') ? '/' : '\\'
 		path += 'poster.png'
 
@@ -429,13 +429,15 @@ export class MetadataController {
 		)
 
 		for (let a of arcs) {
-			let path = await Context.library.getLibraryFolder()
+			let path = resolveSeriesRootFolder(await Context.library.getLibraryFolder())
 			path += path.includes('/') ? '/' : '\\'
-			path += environment.LIBRARY_SERIES_FOLDER_NAME
-			path += path.includes('/') ? '/' : '\\'
-			path += `Season ${String(a.part).padStart(2, '0')}`
-			path += path.includes('/') ? '/' : '\\'
-			path += `poster.png`
+			if (environment.LIBRARY_MEDIA_SERVER === 'none') {
+				path += resolveSeasonPosterFileName(a.part)
+			} else {
+				path += `Season ${String(a.part).padStart(2, '0')}`
+				path += path.includes('/') ? '/' : '\\'
+				path += `poster.png`
+			}
 
 			let NFO = `<?xml version='1.0' encoding='utf-8'?>\n${js2xml(
 				{

--- a/src/util/resolve-season-poster-filename.ts
+++ b/src/util/resolve-season-poster-filename.ts
@@ -1,0 +1,3 @@
+export default function resolveSeasonPosterFileName(arc: number): string {
+	return `season${String(arc).padStart(2, '0')}-poster.png`
+}

--- a/src/util/resolve-series-root-folder.ts
+++ b/src/util/resolve-series-root-folder.ts
@@ -1,0 +1,22 @@
+import environment from '../environment.js'
+
+export default function resolveSeriesRootFolder(libraryFolder: string): string {
+	if (environment.LIBRARY_MEDIA_SERVER === 'none') {
+		return libraryFolder
+	}
+
+	let folder = libraryFolder
+	folder += folder.includes('/') ? '/' : '\\'
+	folder += environment.LIBRARY_SERIES_FOLDER_NAME
+	return folder
+}
+
+export function resolveSeasonFolder(
+	libraryFolder: string,
+	arc: number,
+): string {
+	let folder = resolveSeriesRootFolder(libraryFolder)
+	folder += folder.includes('/') ? '/' : '\\'
+	folder += `Season ${String(arc).padStart(2, '0')}`
+	return folder
+}


### PR DESCRIPTION
**Problem**

With `LIBRARY_MEDIA_SERVER=none`, `LocalFolderController` already resolves the show folder as `LIBRARY_NONE_ROOT_FOLDER` + `LIBRARY_SERIES_FOLDER_NAME`. `LibraryController` and `MetadataController` then appended `LIBRARY_SERIES_FOLDER_NAME` again, so metadata and poster files landed in a duplicated subfolder.

**Solution**

Add `resolve-series-root-folder.ts` and use it when building library paths for local-folder mode. When `none`, use the path from `getLibraryFolder()` directly instead of appending the series folder name a second time.

**Example**

Given:

```
LIBRARY_NONE_ROOT_FOLDER=/data/anime
LIBRARY_SERIES_FOLDER_NAME=One Pace (1999)
```

Before:

```
/data/anime/One Pace (1999)/One Pace (1999)/Season 01/episode.nfo
```

After:

```
/data/anime/One Pace (1999)/Season 01/episode.nfo
```

The first `One Pace (1999)` comes from `LocalFolderController`. The duplicate came from `LibraryController` / `MetadataController` appending `LIBRARY_SERIES_FOLDER_NAME` again.
