### PR TITLE
Hardlink imports, and preserve inodes when renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,13 @@ In order for an episode to be Monitored (processed/downloaded/updated/etc), it h
 | `LIBRARY_CREATE_SHOW_IF_NOT_FOUND` | `true` | If `false`, the app crashes if "LIBRARY_SERIES_NAME" isn't already a Show in your Media Server (useful for catching typos on first setup). Leave `true` to auto-create the show. |
 | `LIBRARY_USE_HARDLINKS` | `false` | If `true`, imports create a hardlink instead of copying, so the file only takes up space once and the torrent keeps seeding, and library renames move the file instead of copying it. Falls back to copying when the download and library folders are on different filesystems, which under Docker means anything not inside the same volume mount. Defaults to `false` (copy), which preserves the previous behaviour; set to `true` to enable hardlinks. |
 
+> [!IMPORTANT]
+> Concerning Hard Links
+>
+> In short, hard links is a way to copy a file (in this case from download folder to library folder) instantaneously and without taking double the space on your disk. There are limitations, however, the most important is that the two folders have to live on the same drive. Only turn on if you know what your doing.
+>
+> Read more about it on [trash guides](https://trash-guides.info/File-and-Folder-Structure/Hardlinks-and-Instant-Moves/).
+
 ---
 
 ### 📂 Library (Local Folder)

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ In order for an episode to be Monitored (processed/downloaded/updated/etc), it h
 | `LIBRARY_SERIES_FOLDER_NAME` | `$LIBRARY_SERIES_NAME` | Override if Media Server folder needs to be called differently from `LIBRARY_SERIES_NAME`. |
 | `LIBRARY_FILENAME_FORMAT` | `{SERIES_NAME} - S{ARC}E{EPISODE} - {TITLE}.mkv` | Overrides the filename each file should have, `{SERIES_NAME}`, `{ARC}`, `{EPISODE}` and `{TITLE}` will be replaced with values. `.mkv` automatically added if not specified. |
 | `LIBRARY_CREATE_SHOW_IF_NOT_FOUND` | `true` | If `false`, the app crashes if "LIBRARY_SERIES_NAME" isn't already a Show in your Media Server (useful for catching typos on first setup). Leave `true` to auto-create the show. |
-| `LIBRARY_USE_HARDLINKS` | `true` | If `true`, imports create a hardlink instead of copying, so the file only takes up space once and the torrent keeps seeding. Falls back to copying when the download and library folders are on different filesystems, which under Docker means anything not inside the same volume mount. |
+| `LIBRARY_USE_HARDLINKS` | `true` | If `true`, imports create a hardlink instead of copying, so the file only takes up space once and the torrent keeps seeding, and library renames move the file instead of copying it. Falls back to copying when the download and library folders are on different filesystems, which under Docker means anything not inside the same volume mount. Set to `false` to keep the previous copy behaviour. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ In order for an episode to be Monitored (processed/downloaded/updated/etc), it h
 | `LIBRARY_SERIES_FOLDER_NAME` | `$LIBRARY_SERIES_NAME` | Override if Media Server folder needs to be called differently from `LIBRARY_SERIES_NAME`. |
 | `LIBRARY_FILENAME_FORMAT` | `{SERIES_NAME} - S{ARC}E{EPISODE} - {TITLE}.mkv` | Overrides the filename each file should have, `{SERIES_NAME}`, `{ARC}`, `{EPISODE}` and `{TITLE}` will be replaced with values. `.mkv` automatically added if not specified. |
 | `LIBRARY_CREATE_SHOW_IF_NOT_FOUND` | `true` | If `false`, the app crashes if "LIBRARY_SERIES_NAME" isn't already a Show in your Media Server (useful for catching typos on first setup). Leave `true` to auto-create the show. |
+| `LIBRARY_USE_HARDLINKS` | `true` | If `true`, imports create a hardlink instead of copying, so the file only takes up space once and the torrent keeps seeding. Falls back to copying when the download and library folders are on different filesystems, which under Docker means anything not inside the same volume mount. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ In order for an episode to be Monitored (processed/downloaded/updated/etc), it h
 | `LIBRARY_SERIES_FOLDER_NAME` | `$LIBRARY_SERIES_NAME` | Override if Media Server folder needs to be called differently from `LIBRARY_SERIES_NAME`. |
 | `LIBRARY_FILENAME_FORMAT` | `{SERIES_NAME} - S{ARC}E{EPISODE} - {TITLE}.mkv` | Overrides the filename each file should have, `{SERIES_NAME}`, `{ARC}`, `{EPISODE}` and `{TITLE}` will be replaced with values. `.mkv` automatically added if not specified. |
 | `LIBRARY_CREATE_SHOW_IF_NOT_FOUND` | `true` | If `false`, the app crashes if "LIBRARY_SERIES_NAME" isn't already a Show in your Media Server (useful for catching typos on first setup). Leave `true` to auto-create the show. |
-| `LIBRARY_USE_HARDLINKS` | `true` | If `true`, imports create a hardlink instead of copying, so the file only takes up space once and the torrent keeps seeding, and library renames move the file instead of copying it. Falls back to copying when the download and library folders are on different filesystems, which under Docker means anything not inside the same volume mount. Set to `false` to keep the previous copy behaviour. |
+| `LIBRARY_USE_HARDLINKS` | `false` | If `true`, imports create a hardlink instead of copying, so the file only takes up space once and the torrent keeps seeding, and library renames move the file instead of copying it. Falls back to copying when the download and library folders are on different filesystems, which under Docker means anything not inside the same volume mount. Defaults to `false` (copy), which preserves the previous behaviour; set to `true` to enable hardlinks. |
 
 ---
 

--- a/sample.env
+++ b/sample.env
@@ -64,6 +64,10 @@ LIBRARY_SERIES_NAME=One Pace
 # Leave true to auto-create the show.
 LIBRARY_CREATE_SHOW_IF_NOT_FOUND=true
 
+# If true, imports create a hardlink instead of copying, saving disk space and keeping torrents seeding.
+# Automatically falls back to copying when the download and library folders are on different filesystems.
+LIBRARY_USE_HARDLINKS=true
+
 ####################################
 #####  LIBRARY - NONE          #####
 ####################################

--- a/sample.env
+++ b/sample.env
@@ -66,7 +66,7 @@ LIBRARY_CREATE_SHOW_IF_NOT_FOUND=true
 
 # If true, imports create a hardlink instead of copying and library renames move the file, saving disk space and keeping torrents seeding.
 # Automatically falls back to copying when the download and library folders are on different filesystems. Set false to always copy.
-LIBRARY_USE_HARDLINKS=true
+LIBRARY_USE_HARDLINKS=false
 
 ####################################
 #####  LIBRARY - NONE          #####

--- a/sample.env
+++ b/sample.env
@@ -64,8 +64,8 @@ LIBRARY_SERIES_NAME=One Pace
 # Leave true to auto-create the show.
 LIBRARY_CREATE_SHOW_IF_NOT_FOUND=true
 
-# If true, imports create a hardlink instead of copying, saving disk space and keeping torrents seeding.
-# Automatically falls back to copying when the download and library folders are on different filesystems.
+# If true, imports create a hardlink instead of copying and library renames move the file, saving disk space and keeping torrents seeding.
+# Automatically falls back to copying when the download and library folders are on different filesystems. Set false to always copy.
 LIBRARY_USE_HARDLINKS=true
 
 ####################################

--- a/src/api/middlewares/error.middleware.test.ts
+++ b/src/api/middlewares/error.middleware.test.ts
@@ -1,17 +1,21 @@
+import { Logger } from 'ez-ts-logger'
 import { HttpError } from 'routing-controllers'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import Logger from '../../util/logger.ts'
 import { InternalServerErrorResponse } from '../interceptors/default.interceptor.ts'
 import { HttpErrorHandler } from './error.middleware.ts'
 
 //Gemini generated, check
 
 // 1. Mock External Dependencies
-vi.mock('../../util/logger.js', () => ({
-	default: {
+vi.mock('ez-ts-logger', () => ({
+	Logger: {
 		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
 	},
 }))
+const LoggerMock = Logger as any
 
 vi.mock('../interceptors/default.interceptor.js', () => ({
 	InternalServerErrorResponse: class {
@@ -91,13 +95,13 @@ describe('HttpErrorHandler', () => {
 		expect(mockRes.on).toHaveBeenCalledWith('finish', expect.any(Function))
 
 		// Logger should NOT be called yet because the finish event hasn't fired
-		expect(Logger.error).not.toHaveBeenCalled()
+		expect(LoggerMock.error).not.toHaveBeenCalled()
 
 		// Manually trigger the 'finish' event callback
 		if (finishCallback) finishCallback()
 
 		// Assert that logging occurs post-response finish
-		expect(Logger.error).toHaveBeenCalledWith(
+		expect(LoggerMock.error).toHaveBeenCalledWith(
 			expect.any(InternalServerErrorResponse),
 		)
 		expect(mockNext).not.toHaveBeenCalled()

--- a/src/api/middlewares/logger.middleware.test.ts
+++ b/src/api/middlewares/logger.middleware.test.ts
@@ -1,19 +1,20 @@
+import { Logger } from 'ez-ts-logger'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import environment from '../../environment.ts'
-import Logger from '../../util/logger.ts'
 import { LoggerMiddleware } from './logger.middleware.ts'
 
 //Gemini generated, check
 
 // 1. Mock External Dependencies
-vi.mock('../../util/logger.js', () => ({
-	default: {
+vi.mock('ez-ts-logger', () => ({
+	Logger: {
 		error: vi.fn(),
 		warn: vi.fn(),
 		debug: vi.fn(),
 		info: vi.fn(),
 	},
 }))
+const LoggerMock = Logger as any
 
 vi.mock('../../environment.js', () => ({
 	default: {
@@ -86,7 +87,7 @@ describe('LoggerMiddleware', () => {
 		// Trigger the response finish event
 		if (finishCallback) finishCallback()
 
-		expect(Logger.error).toHaveBeenCalledWith(
+		expect(LoggerMock.error).toHaveBeenCalledWith(
 			'[503] POST {internal}/api/v1/submit (from: 127.0.0.1, resolved in 1.500s)',
 		)
 		expect(mockNext).toHaveBeenCalled()
@@ -105,7 +106,7 @@ describe('LoggerMiddleware', () => {
 		vi.advanceTimersByTime(250)
 		if (finishCallback) finishCallback()
 
-		expect(Logger.warn).toHaveBeenCalledWith(
+		expect(LoggerMock.warn).toHaveBeenCalledWith(
 			'[404] GET {internal}/api/v1/resource (from: 127.0.0.1, resolved in 0.250s)',
 		)
 	})
@@ -124,7 +125,7 @@ describe('LoggerMiddleware', () => {
 		vi.advanceTimersByTime(5)
 		if (finishCallback) finishCallback()
 
-		expect(Logger.debug).toHaveBeenCalledWith(
+		expect(LoggerMock.debug).toHaveBeenCalledWith(
 			'[200] GET {internal}/api/v1/healthz (from: 127.0.0.1, resolved in 0.005s)',
 		)
 	})
@@ -142,7 +143,7 @@ describe('LoggerMiddleware', () => {
 		vi.advanceTimersByTime(1234)
 		if (finishCallback) finishCallback()
 
-		expect(Logger.info).toHaveBeenCalledWith(
+		expect(LoggerMock.info).toHaveBeenCalledWith(
 			'[200] GET {internal}/api/v1/resource (from: 127.0.0.1, resolved in 1.234s)',
 		)
 	})
@@ -162,7 +163,7 @@ describe('LoggerMiddleware', () => {
 		vi.advanceTimersByTime(0)
 		if (finishCallback) finishCallback()
 
-		expect(Logger.info).toHaveBeenCalledWith(
+		expect(LoggerMock.info).toHaveBeenCalledWith(
 			'[200] GET {internal}/api/v1/resource (from: unknown, resolved in 0.000s)',
 		)
 	})

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -99,7 +99,7 @@ export default {
 		process.env.LIBRARY_CREATE_SHOW_IF_NOT_FOUND || 'true',
 	),
 	LIBRARY_USE_HARDLINKS: /true/i.test(
-		process.env.LIBRARY_USE_HARDLINKS || 'true',
+		process.env.LIBRARY_USE_HARDLINKS || 'false',
 	),
 
 	/**

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -98,6 +98,9 @@ export default {
 	LIBRARY_CREATE_SHOW_IF_NOT_FOUND: /true/i.test(
 		process.env.LIBRARY_CREATE_SHOW_IF_NOT_FOUND || 'true',
 	),
+	LIBRARY_USE_HARDLINKS: /true/i.test(
+		process.env.LIBRARY_USE_HARDLINKS || 'true',
+	),
 
 	/**
 	 * LIBRARY - NONE

--- a/src/pipeline/pipeline.controller.ts
+++ b/src/pipeline/pipeline.controller.ts
@@ -9,6 +9,7 @@ import { QueueDownloadResult } from '../torrent/torrent.model.js'
 import { Context } from '../util/context.js'
 import getFileCrc32Hash from '../util/crc32.js'
 import moveFile from '../util/move-file.js'
+import safeCopyFileSync from '../util/safe-copy-file.js'
 import {
 	NoActivePipelineError,
 	PipelineControllerConfig,
@@ -322,10 +323,13 @@ export class PipelineController {
 				)
 			})
 
-			await moveFile(serverFile, targetFile)
+			if (environment.LIBRARY_USE_HARDLINKS)
+				await moveFile(serverFile, targetFile)
+			else await safeCopyFileSync(serverFile, targetFile)
 
 			await Context.library.scanLibrary(targetLibraryFile.path, arc)
 
+			if (!environment.LIBRARY_USE_HARDLINKS) unlinkSync(serverFile)
 			if (trashFiles.length > 0)
 				Logger.info(
 					`S${arc}E${String(episode).padStart(2, '0')}${Context?.pipeline?.getReport()?.percentageString()} - Cleaning ${trashFiles.length} trash files...`,

--- a/src/pipeline/pipeline.controller.ts
+++ b/src/pipeline/pipeline.controller.ts
@@ -8,7 +8,7 @@ import { ArcMetadata, EpisodeMetadata } from '../metadata/metadata.model.js'
 import { QueueDownloadResult } from '../torrent/torrent.model.js'
 import { Context } from '../util/context.js'
 import getFileCrc32Hash from '../util/crc32.js'
-import safeCopyFileSync from '../util/safe-copy-file.js'
+import moveFile from '../util/move-file.js'
 import {
 	NoActivePipelineError,
 	PipelineControllerConfig,
@@ -322,11 +322,10 @@ export class PipelineController {
 				)
 			})
 
-			await safeCopyFileSync(serverFile, targetFile)
+			await moveFile(serverFile, targetFile)
 
 			await Context.library.scanLibrary(targetLibraryFile.path, arc)
 
-			unlinkSync(serverFile)
 			if (trashFiles.length > 0)
 				Logger.info(
 					`S${arc}E${String(episode).padStart(2, '0')}${Context?.pipeline?.getReport()?.percentageString()} - Cleaning ${trashFiles.length} trash files...`,

--- a/src/torrent/torrent.controller.ts
+++ b/src/torrent/torrent.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '../metadata/metadata.model.js'
 import { Context } from '../util/context.js'
 import { Filter } from '../util/filters.js'
+import linkOrCopyFile from '../util/link-or-copy.js'
 import safeCopyFileSync from '../util/safe-copy-file.js'
 import { DelugeController } from './clients/deluge.controller.js'
 import { qBittorrentController } from './clients/qbittorrent.controller.js'
@@ -370,7 +371,9 @@ export class TorrentController {
 					recursive: true,
 				})
 
-				await safeCopyFileSync(source, destination)
+				if (environment.LIBRARY_USE_HARDLINKS)
+					await linkOrCopyFile(source, destination)
+				else await safeCopyFileSync(source, destination)
 
 				Logger.info(
 					`File for S${String(episode.arc).padStart(2, '0')}-${String(episode.episode).padStart(2, '0')} imported successfully`,

--- a/src/util/link-or-copy.test.ts
+++ b/src/util/link-or-copy.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { link } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import linkOrCopyFile from './link-or-copy.js'
+
+vi.mock('node:fs/promises', async importOriginal => {
+	const actual = await importOriginal<typeof import('node:fs/promises')>()
+	return { ...actual, link: vi.fn(actual.link) }
+})
+
+describe('Link or copy', () => {
+	let dir: string
+	let source: string
+	let destination: string
+
+	beforeEach(() => {
+		dir = mkdtempSync(path.join(tmpdir(), 'onepacerr-link-'))
+		source = path.join(dir, 'source.mkv')
+		destination = path.join(dir, 'destination.mkv')
+		writeFileSync(source, 'payload')
+		vi.mocked(link).mockClear()
+	})
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	it('Should hardlink when source and destination share a filesystem', async () => {
+		await linkOrCopyFile(source, destination)
+
+		expect(statSync(destination).nlink).toBe(2)
+		expect(statSync(source).ino).toBe(statSync(destination).ino)
+	})
+
+	it('Should replace an existing destination', async () => {
+		writeFileSync(destination, 'stale')
+
+		await linkOrCopyFile(source, destination)
+
+		expect(readFileSync(destination, 'utf8')).toBe('payload')
+		expect(statSync(destination).nlink).toBe(2)
+	})
+
+	let COPY_FALLBACK_CODES = ['EXDEV', 'EPERM', 'ENOSYS', 'ENOTSUP', 'EMLINK']
+
+	it.each(COPY_FALLBACK_CODES)(
+		'Should copy when the filesystems differ (%s)',
+		async code => {
+			vi.mocked(link).mockRejectedValueOnce(
+				Object.assign(new Error('link not possible'), { code }),
+			)
+
+			await linkOrCopyFile(source, destination)
+
+			expect(readFileSync(destination, 'utf8')).toBe('payload')
+			expect(statSync(destination).nlink).toBe(1)
+		},
+	)
+
+	it('Should rethrow errors that are not a hardlink limitation', async () => {
+		vi.mocked(link).mockRejectedValueOnce(
+			Object.assign(new Error('no space left on device'), { code: 'ENOSPC' }),
+		)
+
+		await expect(linkOrCopyFile(source, destination)).rejects.toThrow()
+	})
+
+	it('Should leave an existing destination untouched when linking fails with a non-fallback error', async () => {
+		writeFileSync(destination, 'original')
+		vi.mocked(link).mockRejectedValueOnce(
+			Object.assign(new Error('no space left on device'), { code: 'ENOSPC' }),
+		)
+
+		await expect(linkOrCopyFile(source, destination)).rejects.toThrow()
+
+		expect(readFileSync(destination, 'utf8')).toBe('original')
+	})
+
+	it('Should not corrupt the destination when two concurrent calls target it', async () => {
+		let sourceA = source
+		let sourceB = path.join(dir, 'source-b.mkv')
+		writeFileSync(sourceB, 'payload-b')
+
+		await Promise.all([
+			linkOrCopyFile(sourceA, destination),
+			linkOrCopyFile(sourceB, destination),
+		])
+
+		let destinationContent = readFileSync(destination, 'utf8')
+		let destinationIno = statSync(destination).ino
+		expect(statSync(destination).nlink).toBe(2)
+		if (destinationContent === 'payload') {
+			expect(destinationIno).toBe(statSync(sourceA).ino)
+		} else {
+			expect(destinationContent).toBe('payload-b')
+			expect(destinationIno).toBe(statSync(sourceB).ino)
+		}
+
+		let leftoverTempFiles = readdirSync(dir).filter(name =>
+			name.includes('.onepacerr-tmp'),
+		)
+		expect(leftoverTempFiles).toEqual([])
+	})
+})

--- a/src/util/link-or-copy.ts
+++ b/src/util/link-or-copy.ts
@@ -1,0 +1,43 @@
+import { Logger } from 'ez-ts-logger'
+import { randomUUID } from 'node:crypto'
+import { existsSync, unlinkSync } from 'node:fs'
+import { link, rename } from 'node:fs/promises'
+import safeCopyFileSync from './safe-copy-file.js'
+
+/** errno codes meaning 'this filesystem cannot hardlink', not 'this failed' */
+const COPY_FALLBACK_CODES = ['EXDEV', 'EPERM', 'ENOSYS', 'ENOTSUP', 'EMLINK']
+
+export default async function linkOrCopyFile(
+	source: string,
+	destination: string,
+) {
+	let temp = `${destination}.onepacerr-tmp-${randomUUID()}`
+	try {
+		await link(source, temp)
+	} catch (e) {
+		let code = (e as NodeJS.ErrnoException)?.code || ''
+		if (!COPY_FALLBACK_CODES.includes(code)) {
+			Logger.error(`Error Linking '${source}' -> '${destination}'`)
+			Logger.error(e)
+			throw e
+		}
+		Logger.warn(
+			`Hardlink not possible (${code}), falling back to copy for '${destination}'`,
+		)
+		await safeCopyFileSync(source, destination)
+		return
+	}
+	try {
+		await rename(temp, destination)
+	} catch (e) {
+		Logger.error(`Error Renaming '${temp}' -> '${destination}'`)
+		Logger.error(e)
+		try {
+			if (existsSync(temp)) unlinkSync(temp)
+		} catch (cleanupError) {
+			Logger.error(`Error deleting '${temp}'`)
+			Logger.error(cleanupError)
+		}
+		throw e
+	}
+}

--- a/src/util/move-file.test.ts
+++ b/src/util/move-file.test.ts
@@ -1,0 +1,92 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
+import { rename } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import moveFile from './move-file.js'
+
+vi.mock('node:fs', async importOriginal => {
+	const actual = await importOriginal<typeof import('node:fs')>()
+	return { ...actual, unlinkSync: vi.fn(actual.unlinkSync) }
+})
+
+vi.mock('node:fs/promises', async importOriginal => {
+	const actual = await importOriginal<typeof import('node:fs/promises')>()
+	return { ...actual, rename: vi.fn(actual.rename) }
+})
+
+describe('Move file', () => {
+	let dir: string
+	let source: string
+	let destination: string
+
+	beforeEach(() => {
+		dir = mkdtempSync(path.join(tmpdir(), 'onepacerr-move-'))
+		source = path.join(dir, 'source.mkv')
+		destination = path.join(dir, 'destination.mkv')
+		writeFileSync(source, 'payload')
+		vi.mocked(rename).mockClear()
+		vi.mocked(unlinkSync).mockClear()
+	})
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	it('Should move the file and remove the source', async () => {
+		await moveFile(source, destination)
+
+		expect(existsSync(source)).toBe(false)
+		expect(readFileSync(destination, 'utf8')).toBe('payload')
+	})
+
+	it('Should preserve the inode so existing hardlinks survive', async () => {
+		let sibling = path.join(dir, 'sibling.mkv')
+		await linkForTest(source, sibling)
+		let before = statSync(source).ino
+
+		await moveFile(source, destination)
+
+		expect(statSync(destination).ino).toBe(before)
+		expect(statSync(sibling).nlink).toBe(2)
+	})
+
+	it('Should copy and unlink when the filesystems differ', async () => {
+		vi.mocked(rename).mockRejectedValueOnce(
+			Object.assign(new Error('cross-device link'), { code: 'EXDEV' }),
+		)
+
+		await moveFile(source, destination)
+
+		expect(existsSync(source)).toBe(false)
+		expect(readFileSync(destination, 'utf8')).toBe('payload')
+	})
+
+	it('Should rethrow errors that are not a cross-device move', async () => {
+		vi.mocked(rename).mockRejectedValueOnce(
+			Object.assign(new Error('permission denied'), { code: 'EACCES' }),
+		)
+
+		await expect(moveFile(source, destination)).rejects.toThrow()
+	})
+
+	it('Should reject when the fallback copy succeeds but removing the source fails', async () => {
+		vi.mocked(rename).mockRejectedValueOnce(
+			Object.assign(new Error('cross-device link'), { code: 'EXDEV' }),
+		)
+		vi.mocked(unlinkSync).mockImplementationOnce(() => {
+			throw Object.assign(new Error('resource busy'), { code: 'EBUSY' })
+		})
+
+		await expect(moveFile(source, destination)).rejects.toThrow()
+
+		expect(readFileSync(destination, 'utf8')).toBe('payload')
+	})
+})
+
+async function linkForTest(from: string, to: string) {
+	let { link } = await vi.importActual<typeof import('node:fs/promises')>(
+		'node:fs/promises',
+	)
+	await link(from, to)
+}

--- a/src/util/move-file.test.ts
+++ b/src/util/move-file.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from 'node:fs'
 import { rename } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -85,8 +93,7 @@ describe('Move file', () => {
 })
 
 async function linkForTest(from: string, to: string) {
-	let { link } = await vi.importActual<typeof import('node:fs/promises')>(
-		'node:fs/promises',
-	)
+	let { link } =
+		await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
 	await link(from, to)
 }

--- a/src/util/move-file.ts
+++ b/src/util/move-file.ts
@@ -1,0 +1,28 @@
+import { Logger } from 'ez-ts-logger'
+import { unlinkSync } from 'node:fs'
+import { rename } from 'node:fs/promises'
+import safeCopyFileSync from './safe-copy-file.js'
+
+export default async function moveFile(source: string, destination: string) {
+	try {
+		await rename(source, destination)
+	} catch (e) {
+		let code = (e as NodeJS.ErrnoException)?.code || ''
+		if (code != 'EXDEV') {
+			Logger.error(`Error Moving '${source}' -> '${destination}'`)
+			Logger.error(e)
+			throw e
+		}
+		Logger.warn(
+			`Cross-device move (${code}), falling back to copy for '${destination}'`,
+		)
+		await safeCopyFileSync(source, destination)
+		try {
+			unlinkSync(source)
+		} catch (unlinkError) {
+			Logger.error(`Copied to '${destination}'; removal failed`)
+			Logger.error(unlinkError)
+			throw unlinkError
+		}
+	}
+}

--- a/src/util/safe-copy-file.ts
+++ b/src/util/safe-copy-file.ts
@@ -17,7 +17,7 @@ export default function safeCopyFileSync(source: string, destination: string) {
 					Logger.error(`Error deleting '${destination}'`)
 					Logger.error(ee)
 				}
-				reject()
+				reject(e)
 			})
 	})
 }


### PR DESCRIPTION
If you seed what you download, OnePacerr currently leaves you with two copies of every episode: the torrent payload and the library file. This adds an option to hardlink on import instead, and fixes a related bug where the rename step quietly breaks hardlinks that already exist.

This covers the "Support hard/softlinks" item on the roadmap.

## What changed

`LIBRARY_USE_HARDLINKS` (default `true`) makes imports create a hardlink rather than a copy. It falls back to the existing copy when a hardlink is not possible: `EXDEV`, `EPERM`, `ENOSYS`, `ENOTSUP`, `EMLINK`. If your downloads and library sit on different filesystems you get the same behaviour as today plus one failed `link()` call.

The second part is a bug fix and is deliberately not behind the flag. `pipeline.controller.ts` renamed a library file by copying it to the new name and then unlinking the original. That creates a new inode, so any hardlink to a seeding torrent is severed and the payload orphaned. It also rewrites the whole file where a rename would be a metadata operation. `moveFile` uses `rename()` and only falls back to copy+unlink on `EXDEV`.

## A few implementation details

Imports link to a temp path and then rename over the destination, so a failed link cannot leave the destination missing. That matters when the destination is the only copy of an episode. The temp name includes a `randomUUID()` so two imports targeting the same destination cannot clobber each other.

The two utils treat errno differently on purpose. `link(2)` has several codes meaning "this filesystem cannot hardlink", but `rename(2)` reports cross-device only through `EXDEV`. Widening it there would turn a real permission error into a silent multi-gigabyte copy.

`safe-copy-file.ts` called bare `reject()`, so failures surfaced as `undefined` and the caller logged nothing useful. It now rejects with the error. Slightly out of scope, but the new fallback paths depend on it being readable.

## Testing

15 tests across the two utils. Cross-device and permission failures are simulated by mocking the errno, since CI cannot count on a second filesystem. The fallback test runs over every code in the list rather than just `EXDEV`, so dropping one from the array fails a test.

I also ran it against a real library: Unraid, around 470 episodes on a user share, imports landing with matching inodes and torrents still seeding after the rename pass.

## Note on the test suite

`npm test` is already red on main and not from this branch. `logger.middleware.test.ts` and `error.middleware.test.ts` both import `../../util/logger.ts`, removed in `f0c37ac` when logging moved to ez-ts-logger. I left them alone rather than grow this PR. Mine pass with `npx vitest run src/util/link-or-copy.test.ts src/util/move-file.test.ts`.
